### PR TITLE
Handle wider range of TWRP versions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,10 @@ fn try_phrase(phrase: &str) -> bool {
     }
 
     // Regular output, continue
-    if status.success() && stdout == STDOUT_NORMAL && stderr == "" {
+    if status.success()
+        && (stdout == STDOUT_NORMAL || stdout.contains("Failed to decrypt"))
+        && stderr == ""
+    {
         return false;
     }
 


### PR DESCRIPTION
It appears that different versions of TWRP have differing output corresponding to a failed decryption attempt. From what I have seen they do all say "Failed to decrypt ..."; checking for this string allows the tool to handle a wider range of TWRP versions (or possibly differing behavior on different devices).