### PR TITLE
Allow resuming interrupted runs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -86,3 +86,13 @@ pub const PATTERN_DISTANCE_MAX: u16 = 1;
 /// This should be >=10000 because TWRP has a decrypt attempt timeout of about 10 seconds, any new
 /// attempts within that time frame fail with no warning.
 pub const ATTEMPT_DELAY: u64 = 10_500;
+
+/// How far into the pattern list to skip before attempting to continue. This is 0-indexed.
+///
+/// This allows you to resume interrupted runs. For example, if you cancelled apbf after 5 unlock
+/// attempts, setting RESUME_FROM = 5 will skip 5 attempts and start on the 6th.
+///
+/// Note that this is only useful holding all other values in this config.rs file constant between
+/// runs; if you change values that affect what patterns are tried, this value loses meaning and
+/// should not be used.
+pub const RESUME_FROM: usize = 0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,10 +59,12 @@ fn brute_force_pattern(timer: &Timer) {
     // Initialse brute forcing
     println!("Patterns to try: {}", patterns.len());
     let mut pb = ProgressBar::new(patterns.len() as u64);
+    pb.set(RESUME_FROM as u64);
 
     // Try all patterns, start a timer
     patterns
         .into_iter()
+        .skip(RESUME_FROM)
         .inspect(render_pattern)
         .map(|pattern| (generate_phrase(&pattern), pattern))
         .for_each(|(code, pattern)| {


### PR DESCRIPTION
Add rudimentary method of resuming runs. By setting RESUME_FROM in config.rs, when trying patterns the first RESUME_FROM patterns will be skipped. As long as the user knows where they were in the pattern list when they cancelled the program they can resume it from that point by setting this value appropriately.